### PR TITLE
Install supervisor only when needed

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,4 @@
 ---
-dependencies:
-  - { role: supervisor }
-
 galaxy_info:
   author: Alexander Frenzel
   description: Install and manage a syncthing node.

--- a/tasks/syncthing.yml
+++ b/tasks/syncthing.yml
@@ -32,6 +32,10 @@
 - name: set ownership
   file: path={{syncthing_home}} recurse=yes owner={{syncthing_user}} group={{syncthing_user}}
 
+- name: supervisor | install
+  apt: pkg=supervisor state=present
+  when: syncthing_use_supervisor
+
 - name: supervisor | install config
   template: src=supervisor.conf dest=/etc/supervisor/conf.d/syncthing.conf mode=755
   register: supervisor_conf


### PR DESCRIPTION
When I use systemd I don't need supervisor.
Cheers
