### PR TITLE
Fix systemd reload service

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,8 @@
 ---
 - name: restart syncthing
   command: supervisorctl restart syncthing
+  when: syncthing_use_supervisor
+
+- name: restart syncthing
+  command: systemctl restart syncthing
+  when: syncthing_use_systemd

--- a/tasks/syncthing.yml
+++ b/tasks/syncthing.yml
@@ -47,6 +47,7 @@
 
 - name: systemd | install service
   template: src=syncthing.service dest=/etc/systemd/system/syncthing.service mode=755
+  register: systemd_conf
   when: syncthing_use_systemd
 
 - name: systemd | activate service
@@ -55,7 +56,7 @@
 
 - name: systemd | reload service
   service: name=syncthing state=reloaded
-  when: syncthing_use_systemd and systemd_conf_sysemd|changed
+  when: syncthing_use_systemd and systemd_conf|changed
 
 - name: waiting for configfile (takes some time)
   wait_for: path={{syncthing_home}}/.config/syncthing/config.xml


### PR DESCRIPTION
I had an error like:

```
 => |changed expects a dictionary
```

It was just the missing `register` for systemd template.
Cheers
