### PR TITLE
fixed missing quotes and reload in syncthing.yml

### DIFF
--- a/tasks/syncthing.yml
+++ b/tasks/syncthing.yml
@@ -15,7 +15,7 @@
 
 - name: check syncthing version
   become: true
-  become_user: {{ syncthing_user }}"
+  become_user: "{{ syncthing_user }}"
   shell: "{{syncthing_home}}/bin/syncthing --version | awk '{ print $2 }' | cut -c 2-"
   changed_when: false
   ignore_errors: true
@@ -23,20 +23,20 @@
 
 - name: download
   become: true
-  become_user: {{ syncthing_user }}"
+  become_user: "{{ syncthing_user }}"
   get_url: url="{{syncthing_url}}" dest=/tmp/syncthing_{{syncthing_version}}.tar.gz
   when: version|failed or version.stdout != "{{syncthing_version}}"
 
 - name: extract
   become: true
-  become_user: {{ syncthing_user }}"
+  become_user: "{{ syncthing_user }}"
   command: tar xvzf /tmp/syncthing_{{syncthing_version}}.tar.gz -C /tmp
   when: version|failed or version.stdout != "{{syncthing_version}}"
 
 
 - name: copy executable to home dir
   become: true
-  become_user: {{ syncthing_user }}"
+  become_user: "{{ syncthing_user }}"
   shell: cp /tmp/syncthing-*{{syncthing_version}}/syncthing {{syncthing_home}}/bin/syncthing
   when: version|failed or version.stdout != "{{syncthing_version}}"
 
@@ -73,17 +73,17 @@
 
 - name: systemd | reload service
   become: true
-  service: name=syncthing state=reloaded
+  service: name=syncthing state=restarted
   when: syncthing_use_systemd and systemd_conf|changed
 
 - name: waiting for configfile (takes some time)
   become: true
-  become_user: {{ syncthing_user }}"
+  become_user: "{{ syncthing_user }}"
   wait_for: path={{syncthing_home}}/.config/syncthing/config.xml
 
 - name: config.xml | webinterface address
   become: true
-  become_user: {{ syncthing_user }}"
+  become_user: "{{ syncthing_user }}"
   lineinfile: dest={{syncthing_home}}/.config/syncthing/config.xml
               regexp="<address>[^<]+</address>"
               line="        <address>{{syncthing_address}}</address>"
@@ -91,7 +91,7 @@
 
 - name: config.xml | listen address
   become: true
-  become_user: {{ syncthing_user }}"
+  become_user: "{{ syncthing_user }}"
   lineinfile: dest={{syncthing_home}}/.config/syncthing/config.xml
               regexp="<listenAddress>[^<]+</listenAddress>"
               line="        <listenAddress>{{syncthing_listen}}</listenAddress>"
@@ -99,7 +99,7 @@
 
 - name: config.xml | localAnnounceEnabled
   become: true
-  become_user: {{ syncthing_user }}"
+  become_user: "{{ syncthing_user }}"
   lineinfile: dest={{syncthing_home}}/.config/syncthing/config.xml
               regexp="<localAnnounceEnabled>[^<]+</localAnnounceEnabled>"
               line="        <localAnnounceEnabled>{{syncthing_localannounce|lower}}</localAnnounceEnabled>"
@@ -107,7 +107,7 @@
 
 - name: config.xml | globalAnnounceEnabled
   become: true
-  become_user: {{ syncthing_user }}"
+  become_user: "{{ syncthing_user }}"
   lineinfile: dest={{syncthing_home}}/.config/syncthing/config.xml
               regexp="<globalAnnounceEnabled>[^<]+</globalAnnounceEnabled>"
               line="        <globalAnnounceEnabled>{{syncthing_globalannounce|lower}}</globalAnnounceEnabled>"
@@ -115,7 +115,7 @@
 
 - name: config.xml | upnpEnabled
   become: true
-  become_user: {{ syncthing_user }}"
+  become_user: "{{ syncthing_user }}"
   lineinfile: dest={{syncthing_home}}/.config/syncthing/config.xml
               regexp="<upnpEnabled>[^<]+</upnpEnabled>"
               line="        <upnpEnabled>{{syncthing_upnp|lower}}</upnpEnabled>"


### PR DESCRIPTION
reload is not supported in the systemd service file, so we need to restart the syncthing service.

there were a lot of missing quotes in become statements. Maybe some copy-paste issue?